### PR TITLE
Attempt of making the backend clip/ignore curves outside the xlim/ylim.

### DIFF
--- a/mpl_typst/backend.py
+++ b/mpl_typst/backend.py
@@ -241,11 +241,18 @@ class TypstRenderer(RendererBase):
             else:
                 stroke.kwargs.update({'dash': bounds})
 
+        # Get clipping rectangle from graphics context
+        bbox = gc.get_clip_rectangle()
+        clip = None
+        if bbox:
+            p1, p2 = bbox.get_points()
+            clip = (p1[0], p1[1], p2[0], p2[1])
+
         # Since Typst v0.13.0, path drawing API (aka curve) is more coherent to
         # Matplotlib's Path object.
         subpath: list[Call]
         superpath: list[list[Call]] = []
-        for points, code in path.iter_segments(transform):
+        for points, code in path.iter_segments(transform, clip=clip):
             points = normalize(points)
             scalars = tuple([Scalar(p, 'in') for p in points])
             match code:


### PR DESCRIPTION
I had the same issue as #14 . Maybe this is a usable fix?

```
configfile: pyproject.toml
testpaths: mpl_typst
collected 13 items                                                                                                                                                                           

mpl_typst/backend_test.py::TestTypstRenderer::test_draw_path PASSED                                                                                                                    [  7%]
mpl_typst/backend_test.py::TestTypstRenderer::test_draw_image_lenna[72] PASSED                                                                                                         [ 15%]
mpl_typst/backend_test.py::TestTypstRenderer::test_draw_image_lenna[100] PASSED                                                                                                        [ 23%]
mpl_typst/backend_test.py::TestTypstRenderer::test_draw_image_lenna[144] PASSED                                                                                                        [ 30%]
mpl_typst/backend_test.py::TestTypstRenderer::test_draw_image_spy[72] PASSED                                                                                                           [ 38%]
mpl_typst/backend_test.py::TestTypstRenderer::test_draw_image_spy[100] PASSED                                                                                                          [ 46%]
mpl_typst/backend_test.py::TestTypstRenderer::test_draw_image_spy[144] PASSED                                                                                                          [ 53%]
mpl_typst/backend_test.py::TestTypstFigureCanvas::test_print_typ[buffer] PASSED                                                                                                        [ 61%]
mpl_typst/backend_test.py::TestTypstFigureCanvas::test_print_typ[path] PASSED                                                                                                          [ 69%]
mpl_typst/backend_test.py::TestTypstFigureCanvas::test_print_typ[str] PASSED                                                                                                           [ 76%]
mpl_typst/config_test.py::TestConfig::test_from_dict PASSED                                                                                                                            [ 84%]
mpl_typst/config_test.py::TestConfig::test_from_toml PASSED                                                                                                                            [ 92%]
mpl_typst/typst_test.py::test_sanity PASSED                                                                                                                                            [100%]

=========================== 13 passed
```