### PR TITLE
Added simple text coloring, especially for twinx plots ylabels.

### DIFF
--- a/gallery/text-colored.py
+++ b/gallery/text-colored.py
@@ -1,0 +1,27 @@
+#!/usr/bin/env python3
+
+import matplotlib as mpl
+import matplotlib.pyplot as plt
+
+from mpl_typst import rc_context
+
+colors = ['C0', 'C1', 'C2']
+linestyles = ['-', ':', '-.']
+labels = ['text0', 'text1', 'text2']
+
+with rc_context():
+    fig, ax = plt.subplots(1, 1)
+
+    handles = [mpl.lines.Line2D([], [], ls=ls, color=color)
+               for ls, color in zip(linestyles, colors, strict=True)]
+
+    legend = ax.legend(handles, labels, loc='center', ncol=3,
+                       borderaxespad=0.5)
+
+    for text, color in zip(legend.get_texts(), colors, strict=True):
+        text.set_color(color)
+
+    fig.savefig('text-colored.typ')
+    fig.savefig('text-colored.pdf')
+    fig.savefig('text-colored.png')
+    fig.savefig('text-colored.svg')

--- a/mpl_typst/backend.py
+++ b/mpl_typst/backend.py
@@ -517,6 +517,11 @@ class TypstRenderer(RendererBase):
         alignment = 'center + horizon'
         baseline = False
         fontsize = prop.get_size_in_points()
+
+        rgb = gc.get_rgb()
+        hex_color = mpl.colors.to_hex(rgb, keep_alpha=len(rgb) == 4)
+        text_color = Call('rgb', Scalar(hex_color))
+
         if mtext:
             pos = mtext.get_unitless_position()
             x, y = mtext.get_transform().transform(pos)
@@ -536,8 +541,6 @@ class TypstRenderer(RendererBase):
             alignment = f'{halign} + {valign}'
             fontsize = mtext.get_fontsize()
             angle = mtext.get_rotation()
-            rgbText = tuple(gc.get_rgb())[:3]
-            text_color = Call('rgb', *[Scalar(c * 100, '%') for c in rgbText])
         else:
             x = x / self.figure.dpi
             y = self.height + y / self.figure.dpi

--- a/mpl_typst/backend.py
+++ b/mpl_typst/backend.py
@@ -536,6 +536,8 @@ class TypstRenderer(RendererBase):
             alignment = f'{halign} + {valign}'
             fontsize = mtext.get_fontsize()
             angle = mtext.get_rotation()
+            rgbText = tuple(gc.get_rgb())[:3]
+            tcolor = Call('rgb', *[Scalar(c * 100, '%') for c in rgbText])
         else:
             x = x / self.figure.dpi
             y = self.height + y / self.figure.dpi
@@ -547,7 +549,8 @@ class TypstRenderer(RendererBase):
                     size=Scalar(fontsize, 'pt'),
                     alignment=alignment,
                     baseline=baseline,
-                    angle=Scalar(360 - angle, 'deg'))
+                    angle=Scalar(360 - angle, 'deg'),
+                    tcolor=tcolor)
         self.main.append(elem)
 
     def flipy(self):

--- a/mpl_typst/backend.py
+++ b/mpl_typst/backend.py
@@ -537,7 +537,7 @@ class TypstRenderer(RendererBase):
             fontsize = mtext.get_fontsize()
             angle = mtext.get_rotation()
             rgbText = tuple(gc.get_rgb())[:3]
-            tcolor = Call('rgb', *[Scalar(c * 100, '%') for c in rgbText])
+            text_color = Call('rgb', *[Scalar(c * 100, '%') for c in rgbText])
         else:
             x = x / self.figure.dpi
             y = self.height + y / self.figure.dpi
@@ -550,7 +550,7 @@ class TypstRenderer(RendererBase):
                     alignment=alignment,
                     baseline=baseline,
                     angle=Scalar(360 - angle, 'deg'),
-                    tcolor=tcolor)
+                    fill=text_color)
         self.main.append(elem)
 
     def flipy(self):

--- a/mpl_typst/backend_test.py
+++ b/mpl_typst/backend_test.py
@@ -200,6 +200,30 @@ class TestTypstRenderer:
         expected = Image.open(data_dir / 'hatched_rect.png')
         assert_array_equal(actual, expected)
 
+    @pytest.mark.parametrize('color', ['black', 'red', 'green'])
+    def test_draw_text_colored(self, color: str):
+        color_codes = {'black': 0x000000, 'red': 0xff0000, 'green': 0x00ff00}
+        color_code = color_codes[color]
+
+        with rc_context():
+            fig, ax = plt.subplots(figsize=(2, 2), dpi=144)
+            ax.axis(False)
+            ax.text(0, 0, 'Hello, world!', color=f'#{color_code:06x}', size=99)
+            pixels = to_array(fig).astype(np.uint32)
+
+        rgba = (pixels[..., 0] << 24) \
+             | (pixels[..., 1] << 16) \
+             | (pixels[..., 2] << 8) \
+             | (pixels[..., 3] << 0)
+        rgb = (rgba >> 8) & 0xffffff
+
+        non_white = rgb[rgb != 0xffffff]
+        counts, values = np.histogram(non_white)
+        ix = np.argmax(counts)
+        dominant_color = values[ix].astype(np.uint32)  # OK: float64 -> uint32
+
+        assert dominant_color == color_code, 'No any pixel of text color.'
+
     @pytest.mark.parametrize('dpi', [72, 100, 144])
     def test_draw_image_lenna(self, dpi: int):
         img = Image.open(data_dir / 'lenna.png')

--- a/mpl_typst/prologue.typ
+++ b/mpl_typst/prologue.typ
@@ -9,7 +9,7 @@
 
 {{ preamble }}
 
-#let draw-text(dx: 0pt, dy: 0pt, size: 10pt, alignment: center + horizon, baseline: false, angle: 0deg, body) = context {
+#let draw-text(dx: 0pt, dy: 0pt, size: 10pt, alignment: center + horizon, baseline: false, angle: 0deg, tcolor: black, body) = context {
   // In order to align a text properly, we need to configure bounding box of a
   // text.
   let top-edge = "cap-height"
@@ -23,7 +23,7 @@
   }
 
   // Measure shape of text block.
-  let content = text(size: size, top-edge: top-edge, bottom-edge: bot-edge, body)
+  let content = text(size: size, top-edge: top-edge, bottom-edge: bot-edge, fill: tcolor, body)
   let shape = measure(content)
 
   // Adjust horizontal position.

--- a/mpl_typst/prologue.typ
+++ b/mpl_typst/prologue.typ
@@ -9,7 +9,7 @@
 
 {{ preamble }}
 
-#let draw-text(dx: 0pt, dy: 0pt, size: 10pt, alignment: center + horizon, baseline: false, angle: 0deg, tcolor: black, body) = context {
+#let draw-text(dx: 0pt, dy: 0pt, size: 10pt, alignment: center + horizon, baseline: false, angle: 0deg, fill: black, body) = context {
   // In order to align a text properly, we need to configure bounding box of a
   // text.
   let top-edge = "cap-height"
@@ -23,7 +23,7 @@
   }
 
   // Measure shape of text block.
-  let content = text(size: size, top-edge: top-edge, bottom-edge: bot-edge, fill: tcolor, body)
+  let content = text(size: size, top-edge: top-edge, bottom-edge: bot-edge, fill: fill, body)
   let shape = measure(content)
 
   // Adjust horizontal position.


### PR DESCRIPTION
 I wanted something like this
```python
import matplotlib.pyplot as plt
import mpl_typst.as_default

color1="blue"
color2="tab:olive"
sigA = [0, 1, 2, 3, 10]
sigB =[0, -1, -2, -3, -10]

fig, axes = plt.subplots(1,1)
axes.plot(sigA, color=color1)
axes.set_ylabel("Signal A", color=color1)

ax2 = axes.twinx()
ax2.plot(sigB, color=color2)
ax2.set_ylabel("Signal B", color=color2)
fig.savefig("test1.typ")
```

to produce
<img width="400" alt="image" src="https://github.com/user-attachments/assets/1c6984d3-1c9d-4c7a-964e-75b10761597a" />

but the draw_text function in backend.py didn't respect the colors.

This pullrequest should be a simple fix. Not entirely sure how to name the new color variable in the resulting typst file. Chose tcolor for now, to not confuse it with the stroke color (not used yet), but also didn't want do wast more bytes on the additional "ext" of textcolor, but feel free to change that.

If we are add it we could probably also add support for the alpha channel of the text color like [backend_pgf.py](https://github.com/matplotlib/matplotlib/blob/main/lib/matplotlib/backends/backend_pgf.py#L685C1-L688C67). I think the typst rgb color function directly supports the alpha value as an additional forth percent value.