### PR TITLE
Fix image.decode being removed in Typst 0.15

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 ### Fixed
 
 - Add reference test image for rendering changes in Matplotlib 3.11.
+- Handle deprecated `image.decode` symbol since Typst v0.13.0.
 
 ## [0.3.0] - 2026-05-11
 

--- a/mpl_typst/backend.py
+++ b/mpl_typst/backend.py
@@ -37,7 +37,8 @@ if mpl.__version_info__ >= (3, 8):
 else:
     ColorType = Any
 
-from mpl_typst.config import Config, compiler
+import mpl_typst.config as C
+from mpl_typst.config import Config, TypstVersion, compiler
 from mpl_typst.typst import (
     Array, Block, Call, Content, Dictionary, Scalar, Writer as TypstWriter)
 
@@ -331,15 +332,20 @@ class TypstRenderer(RendererBase):
             image_ext = f'.image{next(self._image_counter)}.png'
             image_path = self.path.with_suffix(image_ext)
             img.save(image_path)
-            image = Call('image', f'"{image_path.name}"',
+            image = Call('image.decode', f'"{image_path.name}"',
                          width=Scalar(w, 'in'), height=Scalar(h, 'in'))
         else:
             buf = BytesIO()
             img.save(buf, format='png')
             data = '"' + base64.b64encode(buf.getvalue()).decode('utf-8') + '"'
-            image = Call('image', Call('base64.decode', data),
-                         format='"png"', width=Scalar(w, 'in'),
-                         height=Scalar(h, 'in'))
+            data_decoded = Call('base64.decode', data)
+            # Since typst 0.13.0: `image.decode` deprecated.
+            if C.compiler_version < TypstVersion(0, 13, 0):
+                image = Call('image.decode', data_decoded, format='"png"',
+                             width=Scalar(w, 'in'), height=Scalar(h, 'in'))
+            else:
+                image = Call('image', data_decoded, format='"png"',
+                             width=Scalar(w, 'in'), height=Scalar(h, 'in'))
 
         place = Call('place', 'top + left', image,
                      dx=Scalar(x / self.dpi, 'in'),

--- a/mpl_typst/backend.py
+++ b/mpl_typst/backend.py
@@ -337,7 +337,7 @@ class TypstRenderer(RendererBase):
             buf = BytesIO()
             img.save(buf, format='png')
             data = '"' + base64.b64encode(buf.getvalue()).decode('utf-8') + '"'
-            image = Call('image.decode', Call('base64.decode', data),
+            image = Call('image', Call('base64.decode', data),
                          format='"png"', width=Scalar(w, 'in'),
                          height=Scalar(h, 'in'))
 

--- a/mpl_typst/config.py
+++ b/mpl_typst/config.py
@@ -5,15 +5,8 @@ from dataclasses import dataclass, fields
 from functools import total_ordering
 from os import PathLike, getenv
 from pathlib import Path
-from sys import version_info
-from typing import IO, Any
-
-if version_info >= (3, 11):
-    from tomllib import load as load_toml
-    from typing import Self
-else:
-    from tomli import load as load_toml
-    from typing_extensions import Self
+from tomllib import load as load_toml
+from typing import IO, Any, Self
 
 PREFIX = 'MPL_TYPST_'
 
@@ -52,7 +45,7 @@ class TypstVersion:
     @classmethod
     def from_match(cls, match: re.Match[str]) -> Self:
         prerelease = match.group('prerelease') or ''
-        prerelease_parts: list[int | str, ...] = []
+        prerelease_parts: list[int | str] = []
         for part in prerelease.split('.'):
             if not part:
                 continue
@@ -112,7 +105,10 @@ class TypstVersion:
                 return -1
             if isinstance(left, str) and isinstance(right, int):
                 return 1
-            return 1 - 2 * int(left < right)  # {-1, 1}
+            if isinstance(left, int) and isinstance(right, int):
+                return 1 - 2 * int(left < right)  # {-1, 1}
+            if isinstance(left, str) and isinstance(right, str):
+                return 1 - 2 * int(left < right)  # {-1, 1}
 
         return (len(lhs) > len(rhs)) - (len(lhs) < len(rhs))
 

--- a/mpl_typst/config.py
+++ b/mpl_typst/config.py
@@ -191,4 +191,15 @@ def parse_typst_compiler_version(output: str) -> TypstVersion | None:
 
 
 compiler = get_typst_compiler('compiler')  # MPL_TYPST_COMPILER
-compiler_version = get_typst_compiler_version(compiler)
+compiler_version: TypstVersion | None
+
+
+def __getattr__(name: str) -> Any:
+    """Evaluate some configuration fields lazily."""
+    match name:
+        case 'compiler_version':
+            global compiler_version
+            compiler_version = get_typst_compiler_version(compiler)
+            return compiler_version
+        case _:
+            raise AttributeError(f"'{__name__}' has no attribute '{name}'")

--- a/mpl_typst/config.py
+++ b/mpl_typst/config.py
@@ -1,5 +1,8 @@
+import re
+import subprocess
 import warnings
 from dataclasses import dataclass, fields
+from functools import total_ordering
 from os import PathLike, getenv
 from pathlib import Path
 from sys import version_info
@@ -13,6 +16,105 @@ else:
     from typing_extensions import Self
 
 PREFIX = 'MPL_TYPST_'
+
+SEMVER_PATTERN = (
+    r'(?P<major>0|[1-9]\d*)\.'
+    r'(?P<minor>0|[1-9]\d*)\.'
+    r'(?P<patch>0|[1-9]\d*)'
+    r'(?:-(?P<prerelease>'
+    r'(?:0|[1-9]\d*|\d*[A-Za-z-][0-9A-Za-z-]*)'
+    r'(?:\.(?:0|[1-9]\d*|\d*[A-Za-z-][0-9A-Za-z-]*))*'
+    r'))?'
+    r'(?:\+(?P<build>[0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*))?'
+)
+
+TYPST_COMPILER_VERSION_RE = re.compile(
+    rf'^typst\s+(?P<version>{SEMVER_PATTERN})(?:\s+\((?P<revision>[^)]+)\))?$')
+
+
+@total_ordering
+@dataclass(frozen=True, slots=True, eq=False)
+class TypstVersion:
+    """Semantic Typst compiler version."""
+
+    major: int
+
+    minor: int
+
+    patch: int
+
+    prerelease: tuple[int | str, ...] = ()
+
+    build: str = ''
+
+    revision: str | None = None
+
+    @classmethod
+    def from_match(cls, match: re.Match[str]) -> Self:
+        prerelease = match.group('prerelease') or ''
+        prerelease_parts: list[int | str, ...] = []
+        for part in prerelease.split('.'):
+            if not part:
+                continue
+            if part.isdecimal():
+                prerelease_parts.append(int(part))
+            else:
+                prerelease_parts.append(part)
+
+        return cls(
+            major=int(match.group('major')),
+            minor=int(match.group('minor')),
+            patch=int(match.group('patch')),
+            prerelease=tuple(prerelease_parts),
+            build=match.group('build') or '',
+            revision=match.groupdict().get('revision'),
+        )
+
+    @property
+    def release(self) -> tuple[int, int, int]:
+        return self.major, self.minor, self.patch
+
+    def __str__(self) -> str:
+        version = f'{self.major}.{self.minor}.{self.patch}'
+        if self.prerelease:
+            version += '-' + '.'.join(str(part) for part in self.prerelease)
+        if self.build:
+            version += f'+{self.build}'
+        return version
+
+    def __eq__(self, other: object) -> bool:
+        if not isinstance(other, TypstVersion):
+            return NotImplemented
+        return (self.release,
+                self.prerelease) == (other.release, other.prerelease)
+
+    def __lt__(self, other: object) -> bool:
+        if not isinstance(other, TypstVersion):
+            return NotImplemented
+        if self.release != other.release:
+            return self.release < other.release
+        return self._compare_prerelease(self.prerelease, other.prerelease) < 0
+
+    @staticmethod
+    def _compare_prerelease(lhs: tuple[int | str, ...],
+                            rhs: tuple[int | str, ...],) -> int:
+        if not lhs and not rhs:
+            return 0
+        if not lhs:
+            return 1
+        if not rhs:
+            return -1
+
+        for left, right in zip(lhs, rhs):
+            if left == right:
+                continue
+            if isinstance(left, int) and isinstance(right, str):
+                return -1
+            if isinstance(left, str) and isinstance(right, int):
+                return 1
+            return 1 - 2 * int(left < right)  # {-1, 1}
+
+        return (len(lhs) > len(rhs)) - (len(lhs) < len(rhs))
 
 
 @dataclass(slots=True)
@@ -51,20 +153,42 @@ class Config:
 def get_typst_compiler(name: str, default=Path('typst')) -> Path:
     if (envvar := getenv(f'{PREFIX}{name.upper()}')) is not None:
         path = Path(envvar).expanduser()
-        if not path.exists() or not path.is_file:
+        if not path.exists() or not path.is_file():
             warnings.warn(f'No typst compiler is not found at {path}.',
                           RuntimeWarning)
     else:
         for bin_dir in getenv('PATH', '').split(':'):
-            if (bin_dir / default).exists():
-                path = (bin_dir / default).expanduser()
+            if (Path(bin_dir) / default).exists():
+                path = (Path(bin_dir) / default).expanduser()
                 break
         else:
-            warnings.warn(('Typst compiler found at `PATH` envvar. Consider '
-                           '`MPL_TYPST_COMPILER` envvar to set path to typst '
-                           'compiler explicitely.'), RuntimeWarning)
+            warnings.warn(('No Typst compiler found in `PATH` envvar. '
+                           'Consider `MPL_TYPST_COMPILER` envvar to set path '
+                           'to typst compiler explicitly.'), RuntimeWarning)
             return default
     return path.absolute()
 
 
+def get_typst_compiler_version(path: Path) -> TypstVersion | None:
+    cmd = (str(path), '--version')
+    try:
+        proc = subprocess.run(cmd, capture_output=True, text=True)
+    except OSError:
+        return None
+    if proc.returncode:
+        return None
+    return parse_typst_compiler_version(proc.stdout)
+
+
+def parse_typst_compiler_version(output: str) -> TypstVersion | None:
+    match = TYPST_COMPILER_VERSION_RE.match(output.strip())
+    if match is None:
+        return None
+    try:
+        return TypstVersion.from_match(match)
+    except ValueError:
+        return None
+
+
 compiler = get_typst_compiler('compiler')  # MPL_TYPST_COMPILER
+compiler_version = get_typst_compiler_version(compiler)

--- a/mpl_typst/config_test.py
+++ b/mpl_typst/config_test.py
@@ -1,6 +1,6 @@
 from io import BytesIO
 
-from mpl_typst.config import Config
+from mpl_typst.config import Config, TypstVersion, parse_typst_compiler_version
 
 CONFIG_DICT = {
     'preamble': 'lorem ipsum',
@@ -26,3 +26,35 @@ class TestConfig:
         config = Config.from_toml(buf)
         assert config.preamble == '#let hello = ", world!"'
         assert not config.detached_images
+
+
+class TestTypstVersion:
+
+    def test_parse_release_version(self):
+        output = 'typst 0.14.2 (b33de9de)'
+        version = parse_typst_compiler_version(output)
+
+        assert version == TypstVersion(0, 14, 2, revision='b33de9de')
+        assert version.release == (0, 14, 2)
+        assert version.revision == 'b33de9de'
+        assert str(version) == '0.14.2'
+
+    def test_parse_prerelease_version(self):
+        output = 'typst 0.15.0-rc.1 (c93cf32f)'
+        version = parse_typst_compiler_version(output)
+
+        assert version == TypstVersion(0, 15, 0, ('rc', 1))
+        assert version.prerelease == ('rc', 1)
+        assert version.revision == 'c93cf32f'
+        assert str(version) == '0.15.0-rc.1'
+
+    def test_reject_invalid_version(self):
+        assert parse_typst_compiler_version('typst latest') is None
+        assert parse_typst_compiler_version('typst 0.15') is None
+        assert parse_typst_compiler_version('typst 01.15.0') is None
+
+    def test_compare_prerelease_versions(self):
+        rc1 = TypstVersion(0, 15, 0, ('rc', 1))
+        rc2 = TypstVersion(0, 15, 0, ('rc', 2))
+        release = TypstVersion(0, 15, 0)
+        assert rc1 < rc2 < release

--- a/mpl_typst/config_test.py
+++ b/mpl_typst/config_test.py
@@ -58,3 +58,7 @@ class TestTypstVersion:
         rc2 = TypstVersion(0, 15, 0, ('rc', 2))
         release = TypstVersion(0, 15, 0)
         assert rc1 < rc2 < release
+
+    def test_getattr(self):
+        import mpl_typst.config as C
+        assert C.compiler_version is not None


### PR DESCRIPTION
This function was deprecated in Typst 0.13 and removed in Typst 0.15. The image function now directly accepts bytes as implemented in this PR.